### PR TITLE
little bug in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ response = gcm.send_notification(registration_ids, data: {"message" => "test123"
 Currently `response` is just a hash containing the response `body`, `headers` and `status`.
 
 If the above code is stored in a file like trigger_gcm.rb, thats how you can call it.
-````bash
-ruby -rubygems trigger_gcm.rb
-```
+
+	$ ruby -rubygems trigger_gcm.rb
 
 ##Copyright
 


### PR DESCRIPTION
Hi sabman,

if I use your example code in a script ruby says there is an error with the following line

``` ruby
options = {body: data: {key: "value"}}

./trigger_push.rb:5: odd number list for Hash
options = {body: data:{key: "value"}}
                ^
./trigger_push.rb:5: syntax error, unexpected ':', expecting '}'
options = {body: data:{key: "value"}}
                ^
./trigger_push.rb:5: odd number list for Hash
options = {body: data:{key: "value"}}
                           ^
./trigger_push.rb:5: syntax error, unexpected '}', expecting $end
options = {body: data:{key: "value"}}
```

Both Ruby 1.8.7 and 1.9.3

I fixed it by changing your example script a little. If you want feel free to pull.

Regards,
fritjof
