### PR TITLE
Make ruby gcm compatible with MRI 1.8.7

### DIFF
--- a/lib/gcm.rb
+++ b/lib/gcm.rb
@@ -40,27 +40,27 @@ class GCM
 
     response = self.class.post('', params)
     build_response(response)
-    # {body: response.body, headers: response.headers, status: response.code}
   end
 
   private
 
   def build_post_body(registration_ids, options={})
-    {registration_ids: registration_ids}.merge(options)
+    { :registration_ids => registration_ids }.merge(options)
   end
 
   def build_response(response)
     case response.code
       when 200
-        {response: 'success', body: response.body, headers: response.headers, status_code: response.code}
+        body = response.body || {}
+        { :response => 'success', :body => body, :headers => response.headers, :status_code => response.code }
       when 400
-        {response: 'Only applies for JSON requests. Indicates that the request could not be parsed as JSON, or it contained invalid fields.', status_code: response.code}
+        { :response => 'Only applies for JSON requests. Indicates that the request could not be parsed as JSON, or it contained invalid fields.', :status_code => response.code }
       when 401
-        {response: 'There was an error authenticating the sender account.', status_code: response.code}
+        { :response => 'There was an error authenticating the sender account.', :status_code => response.code }
       when 500
-        {response: 'There was an internal error in the GCM server while trying to process the request.', status_code: response.code}
+        { :response => 'There was an internal error in the GCM server while trying to process the request.', :status_code => response.code }
       when 503
-        {response: 'Server is temporarily unavailable.', status_code: response.code}
+        { :response => 'Server is temporarily unavailable.', :status_code => response.code }
     end
   end
 end

--- a/spec/gcm_spec.rb
+++ b/spec/gcm_spec.rb
@@ -13,7 +13,7 @@ describe GCM do
     let(:api_key) { 'AIzaSyB-1uEai2WiUapxCs2Q0GZYzPu7Udno5aA' }
     let(:registration_ids) { [ "42" ]}
     let(:valid_request_body) do
-      { registration_ids: registration_ids }
+      { :registration_ids => registration_ids }
     end
     let(:valid_request_headers) do
       {
@@ -24,33 +24,33 @@ describe GCM do
 
     before(:each) do
       stub_request(:post, GCM::PUSH_URL).with(
-        body: valid_request_body.to_json,
-        headers: valid_request_headers
+        :body => valid_request_body.to_json,
+        :headers => valid_request_headers
       ).to_return(
         # ref: http://developer.android.com/guide/google/gcm/gcm.html#success
-        body: {},
-        headers: {},
-        status: 200
+        :body => {},
+        :headers => {},
+        :status => 200
       )
     end
 
     it "should send notification using POST to GCM server" do
       gcm = GCM.new(api_key)
-      gcm.send_notification(registration_ids).should eq({response: 'success', body: {}, headers: {}, status_code: 200})
+      gcm.send_notification(registration_ids).should eq({:response => 'success', :body => {}, :headers => {}, :status_code => 200})
     end
 
     context "send notification with data" do
       let!(:stub_with_data){
         stub_request(:post, GCM::PUSH_URL).
-          with(body: "{\"registration_ids\":[\"42\"],\"data\":{\"score\":\"5x1\",\"time\":\"15:10\"}}",
-               headers: valid_request_headers ).
-          to_return(status: 200, body: "", headers: {})
+          with(:body => "{\"data\":{\"score\":\"5x1\",\"time\":\"15:10\"},\"registration_ids\":[\"42\"]}",
+               :headers => valid_request_headers ).
+          to_return(:status => 200, :body => "", :headers => {})
       }
       before do
       end
       it "should send the data in a post request to gcm" do
         gcm = GCM.new(api_key)
-        gcm.send_notification(registration_ids, { data: { score: "5x1", time: "15:10"} })
+        gcm.send_notification(registration_ids, { :data => { :score => "5x1", :time => "15:10"} })
         stub_with_data.should have_been_requested
       end
     end
@@ -59,8 +59,8 @@ describe GCM do
 
       let(:mock_request_attributes) do
         {
-          body: valid_request_body.to_json,
-          headers: valid_request_headers
+          :body => valid_request_body.to_json,
+          :headers => valid_request_headers
         }
       end
 
@@ -72,15 +72,15 @@ describe GCM do
             mock_request_attributes
           ).to_return(
             # ref: http://developer.android.com/guide/google/gcm/gcm.html#success
-            body: {},
-            headers: {},
-            status: 400
+            :body => {},
+            :headers => {},
+            :status => 400
           )
         end
         it "should not send notification due to 400" do
           subject.send_notification(registration_ids).should eq({
             :response => "Only applies for JSON requests. Indicates that the request could not be parsed as JSON, or it contained invalid fields.",
-            :status_code=>400
+            :status_code => 400
           })
         end
       end
@@ -91,16 +91,16 @@ describe GCM do
             mock_request_attributes
           ).to_return(
             # ref: http://developer.android.com/guide/google/gcm/gcm.html#success
-            body: {},
-            headers: {},
-            status: 401
+            :body => {},
+            :headers => {},
+            :status => 401
           )
         end
 
         it "should not send notification due to 401" do
           subject.send_notification(registration_ids).should eq({
-            :response=>"There was an error authenticating the sender account.",
-            :status_code=>401
+            :response => "There was an error authenticating the sender account.",
+            :status_code => 401
           })
         end
       end
@@ -111,16 +111,16 @@ describe GCM do
             mock_request_attributes
           ).to_return(
             # ref: http://developer.android.com/guide/google/gcm/gcm.html#success
-            body: {},
-            headers: {},
-            status: 500
+            :body => {},
+            :headers => {},
+            :status => 500
           )
         end
 
         it "should not send notification due to 500" do
           subject.send_notification(registration_ids).should eq({
-            response: 'There was an internal error in the GCM server while trying to process the request.',
-            status_code: 500
+            :response => 'There was an internal error in the GCM server while trying to process the request.',
+            :status_code => 500
           })
         end
       end
@@ -131,16 +131,16 @@ describe GCM do
             mock_request_attributes
           ).to_return(
             # ref: http://developer.android.com/guide/google/gcm/gcm.html#success
-            body: {},
-            headers: {},
-            status: 503
+            :body => {},
+            :headers => {},
+            :status => 503
           )
         end
 
         it "should not send notification due to 503" do
           subject.send_notification(registration_ids).should eq({
-            response: 'Server is temporarily unavailable.',
-            status_code: 503
+            :response => 'Server is temporarily unavailable.',
+            :status_code => 503
           })
         end
       end


### PR DESCRIPTION
:crying_cat_face: It's sad I still use 1.8 for some stuff.
