### PR TITLE
fix for #17 - 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ response = gcm.create(key_name: "appUser-Chris",
 Now you can send a message to a particular `notification_key` via the `send` method. This allows the server to send a single data to multiple app instances  (typically on multiple devices) owned by a single user (instead of sending to registration IDs). Note: the maximum number of members allowed for a `notification_key` is 10.
 
 ```ruby
-response = gcm.send_message_to_notification_key({
+response = gcm.send_with_notification_key({
             to: "appUser-Chris-key",
             data: {score: "3x1"},
             collapse_key: "updated_score"})

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ response = gcm.create(key_name: "appUser-Chris",
 Now you can send a message to a particular `notification_key` via the `send` method. This allows the server to send a single data to multiple app instances  (typically on multiple devices) owned by a single user (instead of sending to registration IDs). Note: the maximum number of members allowed for a `notification_key` is 10.
 
 ```ruby
-response = gcm.send([], {
-            notification_key: "appUser-Chris-key",
+response = gcm.send_message_to_notification_key({
+            to: "appUser-Chris-key",
             data: {score: "3x1"},
             collapse_key: "updated_score"})
 ```

--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ response = gcm.create(key_name: "appUser-Chris",
 Now you can send a message to a particular `notification_key` via the `send` method. This allows the server to send a single data to multiple app instances  (typically on multiple devices) owned by a single user (instead of sending to registration IDs). Note: the maximum number of members allowed for a `notification_key` is 10.
 
 ```ruby
-response = gcm.send_with_notification_key({
-            to: "appUser-Chris-key",
+response = gcm.send_with_notification_key("notification_key", {
             data: {score: "3x1"},
             collapse_key: "updated_score"})
 ```

--- a/lib/gcm.rb
+++ b/lib/gcm.rb
@@ -101,6 +101,20 @@ class GCM
   end
   alias_method :remove, :remove_registration_ids
 
+  def send_message_to_notification_key(notification_key, options)
+    { :to => notification_key }.merge(options)
+
+    params = {
+      :body => options.to_json,
+      :headers => {
+        'Authorization' => "key=#{@api_key}",
+        'Content-Type' => 'application/json',
+      }
+    }
+    response = self.class.post('/send', params.merge(@client_options))
+    build_response(response)
+  end
+
   private
 
   def build_post_body(registration_ids, options={})

--- a/lib/gcm.rb
+++ b/lib/gcm.rb
@@ -101,7 +101,7 @@ class GCM
   end
   alias_method :remove, :remove_registration_ids
 
-  def send_message_to_notification_key(notification_key, options)
+  def send_with_notification_key(notification_key, options)
     { :to => notification_key }.merge(options)
 
     params = {

--- a/lib/gcm.rb
+++ b/lib/gcm.rb
@@ -102,10 +102,10 @@ class GCM
   alias_method :remove, :remove_registration_ids
 
   def send_with_notification_key(notification_key, options)
-    { :to => notification_key }.merge(options)
+    body = { :to => notification_key }.merge(options)
 
     params = {
-      :body => options.to_json,
+      :body => body.to_json,
       :headers => {
         'Authorization' => "key=#{@api_key}",
         'Content-Type' => 'application/json',


### PR DESCRIPTION
fix for #17 - 
There is a bug in Google documentation. The request should include the notification key like this

    to: <notification_key>

rather than

    notification_key: <notification_key>

The request will also fail if it includes a `registration_ids` array, even if it is empty.

See this StackOverflow post for more - http://stackoverflow.com/questions/19720767/gcm-user-notifications-missing-registration-ids-field/25183892#25183892

This pull request adds a method #send_with_notification_key which formats the request correctly.

I haven't added any further tests as I'm not that familar with how you are mocking the requests, but the few existing tests are passing ok.
I'll try to get a chance to add some tests at some stage.