### PR TITLE
change end point to new FCM platform.

### DIFF
--- a/lib/gcm.rb
+++ b/lib/gcm.rb
@@ -4,7 +4,7 @@ require 'json'
 
 class GCM
   include HTTParty
-  base_uri 'https://gcm-http.googleapis.com/gcm'
+  base_uri 'https://fcm.googleapis.com/fcm/send'
   default_timeout 30
   format :json
 


### PR DESCRIPTION
[Firebase Cloud Messaging (FCM)](https://firebase.google.com/docs/cloud-messaging/) is the new version of GCM. It inherits the reliable and scalable GCM infrastructure, plus new features! See the FAQ to learn more. If you are integrating messaging in a new app, start with FCM. GCM users are strongly recommended to upgrade to FCM, in order to benefit from new FCM features today and in the future.